### PR TITLE
Skip AUR helper installation on Fedora-based systems

### DIFF
--- a/Scripts/install_pkg.sh
+++ b/Scripts/install_pkg.sh
@@ -15,8 +15,12 @@ fi
 flg_DryRun=${flg_DryRun:-0}
 export log_section="package"
 
-"${scrDir}/install_aur.sh" "${getAur}" 2>&1
-chk_list "aurhlpr" "${aurList[@]}"
+# Check if the system is Fedora or RPM-based
+if ! is_fedora; then
+    "${scrDir}/install_aur.sh" "${getAur}" 2>&1
+    chk_list "aurhlpr" "${aurList[@]}"
+fi
+
 listPkg="${1:-"${scrDir}/pkg_core.lst"}"
 archPkg=()
 aurhPkg=()


### PR DESCRIPTION
Add a check for Fedora or RPM-based systems before calling `install_aur.sh` in `Scripts/install_pkg.sh`.

* Check if the system is Fedora or RPM-based before calling `install_aur.sh`.
* Skip calling `install_aur.sh` if the system is Fedora or RPM-based.

